### PR TITLE
Adicionando arquivo de contribuidores

### DIFF
--- a/CONTRIBUITORS.md
+++ b/CONTRIBUITORS.md
@@ -15,5 +15,41 @@ Contribuidores do Projeto - Incluido aqueles não mostrados pelo Git
 
 * **[João Antônio Cardoso](https://github.com/joaoantoniocardoso)**
 
+* **Marcelo Knörich Zuffo**
+
+  * Coordenador do projeto
+
+* **Raúl gonzalez lima**
+
+  * Coordenador do projeto
+
+* **Alembert eistein lino alvarado**
+
+  * Equipe Técnica
+
+* **Dario GramorellI**
+
+  * Equipe Técnica
+
+* **Felipe Fava de Lima**
+
+  * Equipe Técnica
+
+* **Francisco Baccaro Nigro**
+
+  * Equipe Técnica
+
+* **Henrique Takachi Moriya**
+
+  * Equipe Técnica
+
+* **Silvio Andrade Figueiredo**
+
+  * Equipe Técnica
+
+* **Renato de Lima Vitorasso**
+
+  * Equipe Técnica
+
 **[Lista de contribuidores com conta no github atualizada](https://github.com/Inspire-Poli-USP/Inspire-OpenLung/graphs/contributors).**
 

--- a/CONTRIBUITORS.md
+++ b/CONTRIBUITORS.md
@@ -1,0 +1,19 @@
+Contribuidores do Projeto - Incluido aqueles não mostrados pelo Git
+============================================
+
+* **[Otto Heringer](https://github.com/OttoHeringer)**
+
+* **[Breno Helfstein Moura](https://github.com/breno-helf/)**
+
+  * Organização do repositório e explicações de git para organizadores
+
+* **[Emerson Moretto](https://github.com/emersonmoretto)**
+
+* **[Matheus Tavares](https://github.com/matheustavares)**
+
+* **[Wendell Pereira da Silva](https://github.com/silvawp)**
+
+* **[João Antônio Cardoso](https://github.com/joaoantoniocardoso)**
+
+**[Lista de contribuidores com conta no github atualizada](https://github.com/Inspire-Poli-USP/Inspire-OpenLung/graphs/contributors).**
+


### PR DESCRIPTION
Criando arquivo de contribuidores para a inclusão de contribuidores de fora do git como pedido na issue #52 . Acredito que já poderiamos incluir o Marcelo Knörich Zuffo e o Raúl gonzalez lima e todos os outros nomes do site (https://www.poli.usp.br/inspire), mas não tenho certeza, pode conferir isso @OttoHeringer ?